### PR TITLE
Scroll baseline — render full document as flat visible page

### DIFF
--- a/SemanticText/src/App.css
+++ b/SemanticText/src/App.css
@@ -1,184 +1,36 @@
-.counter {
-  font-size: 16px;
-  padding: 5px 10px;
-  border-radius: 5px;
-  color: var(--accent);
-  background: var(--accent-bg);
-  border: 2px solid transparent;
-  transition: border-color 0.3s;
-  margin-bottom: 24px;
-
-  &:hover {
-    border-color: var(--accent-border);
-  }
-  &:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-  }
-}
-
-.hero {
-  position: relative;
-
-  .base,
-  .framework,
-  .vite {
-    inset-inline: 0;
-    margin: 0 auto;
-  }
-
-  .base {
-    width: 170px;
-    position: relative;
-    z-index: 0;
-  }
-
-  .framework,
-  .vite {
-    position: absolute;
-  }
-
-  .framework {
-    z-index: 1;
-    top: 34px;
-    height: 28px;
-    transform: perspective(2000px) rotateZ(300deg) rotateX(44deg) rotateY(39deg)
-      scale(1.4);
-  }
-
-  .vite {
-    z-index: 0;
-    top: 107px;
-    height: 26px;
-    width: auto;
-    transform: perspective(2000px) rotateZ(300deg) rotateX(40deg) rotateY(39deg)
-      scale(0.8);
-  }
-}
-
-#center {
+.app-shell {
   display: flex;
   flex-direction: column;
-  gap: 25px;
-  place-content: center;
-  place-items: center;
-  flex-grow: 1;
-
-  @media (max-width: 1024px) {
-    padding: 32px 20px 24px;
-    gap: 18px;
-  }
+  min-height: 100vh;
+  background: #fff;
 }
 
-#next-steps {
+.app-header {
   display: flex;
-  border-top: 1px solid var(--border);
-  text-align: left;
-
-  & > div {
-    flex: 1 1 0;
-    padding: 32px;
-    @media (max-width: 1024px) {
-      padding: 24px 20px;
-    }
-  }
-
-  .icon {
-    margin-bottom: 16px;
-    width: 22px;
-    height: 22px;
-  }
-
-  @media (max-width: 1024px) {
-    flex-direction: column;
-    text-align: center;
-  }
+  align-items: center;
+  padding: 0 1.5rem;
+  height: 52px;
+  background: #1a73e8;
+  color: #fff;
+  flex-shrink: 0;
 }
 
-#docs {
-  border-right: 1px solid var(--border);
-
-  @media (max-width: 1024px) {
-    border-right: none;
-    border-bottom: 1px solid var(--border);
-  }
+.app-brand {
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
 }
 
-#next-steps ul {
-  list-style: none;
-  padding: 0;
+.app-content {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.placeholder {
   display: flex;
-  gap: 8px;
-  margin: 32px 0 0;
-
-  .logo {
-    height: 18px;
-  }
-
-  a {
-    color: var(--text-h);
-    font-size: 16px;
-    border-radius: 6px;
-    background: var(--social-bg);
-    display: flex;
-    padding: 6px 12px;
-    align-items: center;
-    gap: 8px;
-    text-decoration: none;
-    transition: box-shadow 0.3s;
-
-    &:hover {
-      box-shadow: var(--shadow);
-    }
-    .button-icon {
-      height: 18px;
-      width: 18px;
-    }
-  }
-
-  @media (max-width: 1024px) {
-    margin-top: 20px;
-    flex-wrap: wrap;
-    justify-content: center;
-
-    li {
-      flex: 1 1 calc(50% - 8px);
-    }
-
-    a {
-      width: 100%;
-      justify-content: center;
-      box-sizing: border-box;
-    }
-  }
-}
-
-#spacer {
-  height: 88px;
-  border-top: 1px solid var(--border);
-  @media (max-width: 1024px) {
-    height: 48px;
-  }
-}
-
-.ticks {
-  position: relative;
-  width: 100%;
-
-  &::before,
-  &::after {
-    content: '';
-    position: absolute;
-    top: -4.5px;
-    border: 5px solid transparent;
-  }
-
-  &::before {
-    left: 0;
-    border-left-color: var(--border);
-  }
-  &::after {
-    right: 0;
-    border-right-color: var(--border);
-  }
+  align-items: center;
+  justify-content: center;
+  height: 60vh;
+  color: #888;
+  font-size: 1.1rem;
 }

--- a/SemanticText/src/App.tsx
+++ b/SemanticText/src/App.tsx
@@ -1,121 +1,34 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from './assets/vite.svg'
-import heroImg from './assets/hero.png'
-import './App.css'
+import { useState } from "react";
+import ViewTabs, { type ViewMode } from "./components/ViewTabs";
+import ScrollView from "./components/ScrollView";
+import type { Document } from "./data/types";
+import beatlesData from "./data/beatles.json";
+import "./App.css";
 
-function App() {
-  const [count, setCount] = useState(0)
+const doc = beatlesData as Document;
 
+function Placeholder({ label }: { label: string }) {
   return (
-    <>
-      <section id="center">
-        <div className="hero">
-          <img src={heroImg} className="base" width="170" height="179" alt="" />
-          <img src={reactLogo} className="framework" alt="React logo" />
-          <img src={viteLogo} className="vite" alt="Vite logo" />
-        </div>
-        <div>
-          <h1>Get started</h1>
-          <p>
-            Edit <code>src/App.tsx</code> and save to test <code>HMR</code>
-          </p>
-        </div>
-        <button
-          className="counter"
-          onClick={() => setCount((count) => count + 1)}
-        >
-          Count is {count}
-        </button>
-      </section>
-
-      <div className="ticks"></div>
-
-      <section id="next-steps">
-        <div id="docs">
-          <svg className="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#documentation-icon"></use>
-          </svg>
-          <h2>Documentation</h2>
-          <p>Your questions, answered</p>
-          <ul>
-            <li>
-              <a href="https://vite.dev/" target="_blank">
-                <img className="logo" src={viteLogo} alt="" />
-                Explore Vite
-              </a>
-            </li>
-            <li>
-              <a href="https://react.dev/" target="_blank">
-                <img className="button-icon" src={reactLogo} alt="" />
-                Learn more
-              </a>
-            </li>
-          </ul>
-        </div>
-        <div id="social">
-          <svg className="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#social-icon"></use>
-          </svg>
-          <h2>Connect with us</h2>
-          <p>Join the Vite community</p>
-          <ul>
-            <li>
-              <a href="https://github.com/vitejs/vite" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#github-icon"></use>
-                </svg>
-                GitHub
-              </a>
-            </li>
-            <li>
-              <a href="https://chat.vite.dev/" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#discord-icon"></use>
-                </svg>
-                Discord
-              </a>
-            </li>
-            <li>
-              <a href="https://x.com/vite_js" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#x-icon"></use>
-                </svg>
-                X.com
-              </a>
-            </li>
-            <li>
-              <a href="https://bsky.app/profile/vite.dev" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#bluesky-icon"></use>
-                </svg>
-                Bluesky
-              </a>
-            </li>
-          </ul>
-        </div>
-      </section>
-
-      <div className="ticks"></div>
-      <section id="spacer"></section>
-    </>
-  )
+    <div className="placeholder">
+      <p>{label} view — coming soon.</p>
+    </div>
+  );
 }
 
-export default App
+export default function App() {
+  const [mode, setMode] = useState<ViewMode>("scrolling");
+
+  return (
+    <div className="app-shell">
+      <header className="app-header">
+        <span className="app-brand">Textual Semantic Zoom</span>
+      </header>
+      <ViewTabs active={mode} onChange={setMode} />
+      <main className="app-content">
+        {mode === "scrolling" && <ScrollView doc={doc} />}
+        {mode === "accordion" && <Placeholder label="Accordion" />}
+        {mode === "semantic" && <Placeholder label="Semantic Zoom" />}
+      </main>
+    </div>
+  );
+}

--- a/SemanticText/src/components/ScrollView.css
+++ b/SemanticText/src/components/ScrollView.css
@@ -1,0 +1,51 @@
+.scroll-view {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 2rem 1rem 4rem;
+  font-family: Georgia, "Times New Roman", serif;
+  line-height: 1.75;
+  color: #1a1a1a;
+}
+
+.scroll-doc-title {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 2rem;
+  border-bottom: 2px solid #e0e0e0;
+  padding-bottom: 0.75rem;
+}
+
+.scroll-section {
+  margin-bottom: 2.5rem;
+}
+
+.scroll-section-title {
+  font-size: 1.35rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: #222;
+}
+
+.scroll-segment {
+  margin-bottom: 0.85rem;
+}
+
+/* Subtle typographic depth cues — no gating, just visual rhythm */
+.scroll-segment.depth-0 {
+  font-size: 1rem;
+}
+
+.scroll-segment.depth-1 {
+  font-size: 0.95rem;
+  color: #333;
+}
+
+.scroll-segment.depth-2 {
+  font-size: 0.9rem;
+  color: #555;
+}
+
+/* Terms are plain text in scroll mode — no interaction */
+.scroll-term {
+  font-style: italic;
+}

--- a/SemanticText/src/components/ScrollView.css
+++ b/SemanticText/src/components/ScrollView.css
@@ -30,20 +30,6 @@
   margin-bottom: 0.85rem;
 }
 
-/* Subtle typographic depth cues — no gating, just visual rhythm */
-.scroll-segment.depth-0 {
-  font-size: 1rem;
-}
-
-.scroll-segment.depth-1 {
-  font-size: 0.95rem;
-  color: #333;
-}
-
-.scroll-segment.depth-2 {
-  font-size: 0.9rem;
-  color: #555;
-}
 
 /* Terms are plain text in scroll mode — no interaction */
 .scroll-term {

--- a/SemanticText/src/components/ScrollView.tsx
+++ b/SemanticText/src/components/ScrollView.tsx
@@ -22,7 +22,7 @@ export default function ScrollView({ doc }: Props) {
         <section key={section.id} className="scroll-section">
           <h2 className="scroll-section-title">{section.title}</h2>
           {section.segments.map((seg) => (
-            <p key={seg.id} className={`scroll-segment depth-${seg.depth}`}>
+            <p key={seg.id} className="scroll-segment">
               {renderTokens(seg.content)}
             </p>
           ))}

--- a/SemanticText/src/components/ScrollView.tsx
+++ b/SemanticText/src/components/ScrollView.tsx
@@ -1,0 +1,33 @@
+import type { Document, Token } from "../data/types";
+import "./ScrollView.css";
+
+interface Props {
+  doc: Document;
+}
+
+function renderTokens(tokens: Token[]) {
+  return tokens.map((tok, i) => {
+    if (tok.type === "term") {
+      return <span key={i} className="scroll-term">{tok.text}</span>;
+    }
+    return <span key={i}>{tok.text}</span>;
+  });
+}
+
+export default function ScrollView({ doc }: Props) {
+  return (
+    <article className="scroll-view">
+      <h1 className="scroll-doc-title">{doc.title}</h1>
+      {doc.sections.map((section) => (
+        <section key={section.id} className="scroll-section">
+          <h2 className="scroll-section-title">{section.title}</h2>
+          {section.segments.map((seg) => (
+            <p key={seg.id} className={`scroll-segment depth-${seg.depth}`}>
+              {renderTokens(seg.content)}
+            </p>
+          ))}
+        </section>
+      ))}
+    </article>
+  );
+}

--- a/SemanticText/src/components/ViewTabs.css
+++ b/SemanticText/src/components/ViewTabs.css
@@ -1,0 +1,32 @@
+.view-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 2px solid #d0d0d0;
+  margin-bottom: 0;
+  padding: 0 1.5rem;
+  background: #f8f8f8;
+}
+
+.view-tab {
+  padding: 0.65rem 1.4rem;
+  font-size: 0.95rem;
+  font-weight: 500;
+  background: none;
+  border: none;
+  border-bottom: 3px solid transparent;
+  margin-bottom: -2px;
+  cursor: pointer;
+  color: #555;
+  letter-spacing: 0.01em;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.view-tab:hover {
+  color: #111;
+}
+
+.view-tab--active {
+  color: #111;
+  border-bottom-color: #1a73e8;
+  font-weight: 600;
+}

--- a/SemanticText/src/components/ViewTabs.tsx
+++ b/SemanticText/src/components/ViewTabs.tsx
@@ -1,0 +1,32 @@
+import "./ViewTabs.css";
+
+export type ViewMode = "scrolling" | "accordion" | "semantic";
+
+interface Props {
+  active: ViewMode;
+  onChange: (mode: ViewMode) => void;
+}
+
+const TABS: { id: ViewMode; label: string }[] = [
+  { id: "semantic", label: "Semantic" },
+  { id: "accordion", label: "Accordion" },
+  { id: "scrolling", label: "Scrolling" },
+];
+
+export default function ViewTabs({ active, onChange }: Props) {
+  return (
+    <nav className="view-tabs" role="tablist" aria-label="View mode">
+      {TABS.map((tab) => (
+        <button
+          key={tab.id}
+          role="tab"
+          aria-selected={active === tab.id}
+          className={`view-tab ${active === tab.id ? "view-tab--active" : ""}`}
+          onClick={() => onChange(tab.id)}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </nav>
+  );
+}

--- a/SemanticText/src/index.css
+++ b/SemanticText/src/index.css
@@ -51,11 +51,7 @@
 }
 
 #root {
-  width: 1126px;
-  max-width: 100%;
-  margin: 0 auto;
-  text-align: center;
-  border-inline: 1px solid var(--border);
+  width: 100%;
   min-height: 100svh;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Closes #2

## Summary
- Adds `ScrollView` component that flattens all JSON layers into a single continuous scrollable article
- All depth tiers render as uniform prose (no gating, no interaction on terms)
- Adds `ViewTabs` component with **Semantic | Accordion | Scrolling** tabs; Scrolling is selected by default
- Accordion and Semantic tabs show placeholders for future issues

## Test plan
- [x] Run `npm run dev` in `SemanticText/` and open the app
- [x] Scrolling tab is selected on load and shows the full Beatles article
- [x] All paragraphs within sections render at identical font size and colour
- [x] Expandable terms appear as plain italic text with no click behaviour
- [x] Switching to Accordion and Semantic tabs shows "coming soon" placeholders