### PR TITLE
Accordion baseline — section-gated expand/collapse interface

### DIFF
--- a/SemanticText/src/App.tsx
+++ b/SemanticText/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import ViewTabs, { type ViewMode } from "./components/ViewTabs";
 import ScrollView from "./components/ScrollView";
+import AccordionView from "./components/AccordionView";
 import type { Document } from "./data/types";
 import beatlesData from "./data/beatles.json";
 import "./App.css";
@@ -26,7 +27,7 @@ export default function App() {
       <ViewTabs active={mode} onChange={setMode} />
       <main className="app-content">
         {mode === "scrolling" && <ScrollView doc={doc} />}
-        {mode === "accordion" && <Placeholder label="Accordion" />}
+        {mode === "accordion" && <AccordionView doc={doc} />}
         {mode === "semantic" && <Placeholder label="Semantic Zoom" />}
       </main>
     </div>

--- a/SemanticText/src/components/AccordionView.css
+++ b/SemanticText/src/components/AccordionView.css
@@ -1,0 +1,98 @@
+.accordion-view {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 2rem 1rem 4rem;
+  font-family: Georgia, "Times New Roman", serif;
+  line-height: 1.75;
+  color: #1a1a1a;
+}
+
+.accordion-doc-title {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 2rem;
+  border-bottom: 2px solid #e0e0e0;
+  padding-bottom: 0.75rem;
+}
+
+.accordion-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.accordion-item {
+  border: 1px solid #d8d8d8;
+  border-radius: 6px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.accordion-item--open {
+  border-color: #1a73e8;
+}
+
+.accordion-header {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.85rem 1.2rem;
+  background: #f5f5f5;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s;
+}
+
+.accordion-item--open .accordion-header {
+  background: #e8f0fe;
+}
+
+.accordion-header:hover {
+  background: #ebebeb;
+}
+
+.accordion-item--open .accordion-header:hover {
+  background: #d2e3fc;
+}
+
+.accordion-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #222;
+  font-family: Georgia, "Times New Roman", serif;
+}
+
+.accordion-chevron {
+  font-size: 0.75rem;
+  color: #666;
+  flex-shrink: 0;
+  margin-left: 1rem;
+}
+
+.accordion-preview {
+  padding: 0.5rem 1.2rem;
+  font-size: 0.8rem;
+  color: #999;
+  font-style: italic;
+  font-family: Georgia, "Times New Roman", serif;
+  border-top: 1px dashed #e0e0e0;
+}
+
+.accordion-body {
+  padding: 1rem 1.2rem 1.25rem;
+  border-top: 1px solid #e0e0e0;
+}
+
+.accordion-segment {
+  margin-bottom: 0.85rem;
+}
+
+.accordion-segment:last-child {
+  margin-bottom: 0;
+}
+
+.accordion-term {
+  font-style: italic;
+}

--- a/SemanticText/src/components/AccordionView.css
+++ b/SemanticText/src/components/AccordionView.css
@@ -22,14 +22,14 @@
 }
 
 .accordion-item {
-  border: 1px solid #d8d8d8;
+  border: 1px solid #1a73e8;
   border-radius: 6px;
   overflow: hidden;
   background: #fff;
 }
 
 .accordion-item--open {
-  border-color: #1a73e8;
+  border-color: #d8d8d8;
 }
 
 .accordion-header {
@@ -38,7 +38,7 @@
   justify-content: space-between;
   align-items: center;
   padding: 0.85rem 1.2rem;
-  background: #f5f5f5;
+  background: #e8f0fe;
   border: none;
   cursor: pointer;
   text-align: left;
@@ -46,15 +46,15 @@
 }
 
 .accordion-item--open .accordion-header {
-  background: #e8f0fe;
+  background: #f5f5f5;
 }
 
 .accordion-header:hover {
-  background: #ebebeb;
+  background: #d2e3fc;
 }
 
 .accordion-item--open .accordion-header:hover {
-  background: #d2e3fc;
+  background: #ebebeb;
 }
 
 .accordion-title {

--- a/SemanticText/src/components/AccordionView.tsx
+++ b/SemanticText/src/components/AccordionView.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import type { Document, Token } from "../data/types";
+import "./AccordionView.css";
+
+interface Props {
+  doc: Document;
+}
+
+function renderTokens(tokens: Token[]) {
+  return tokens.map((tok, i) => {
+    if (tok.type === "term") {
+      return <span key={i} className="accordion-term">{tok.text}</span>;
+    }
+    return <span key={i}>{tok.text}</span>;
+  });
+}
+
+export default function AccordionView({ doc }: Props) {
+  const [openSections, setOpenSections] = useState<Set<string>>(new Set());
+
+  function toggle(id: string) {
+    setOpenSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
+  return (
+    <article className="accordion-view">
+      <h1 className="accordion-doc-title">{doc.title}</h1>
+      <div className="accordion-list">
+        {doc.sections.map((section) => {
+          const isOpen = openSections.has(section.id);
+          return (
+            <div key={section.id} className={`accordion-item${isOpen ? " accordion-item--open" : ""}`}>
+              <button
+                className="accordion-header"
+                aria-expanded={isOpen}
+                onClick={() => toggle(section.id)}
+              >
+                <span className="accordion-title">{section.title}</span>
+                <span className="accordion-chevron" aria-hidden="true">
+                  {isOpen ? "▲" : "▼"}
+                </span>
+              </button>
+              {isOpen && (
+                <div className="accordion-body">
+                  {section.segments.map((seg) => (
+                    <p key={seg.id} className="accordion-segment">
+                      {renderTokens(seg.content)}
+                    </p>
+                  ))}
+                </div>
+              )}
+              {!isOpen && (
+                <div className="accordion-preview" aria-hidden="true">
+                  {section.segments.length} paragraph{section.segments.length !== 1 ? "s" : ""} hidden
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </article>
+  );
+}

--- a/SemanticText/src/components/ViewTabs.tsx
+++ b/SemanticText/src/components/ViewTabs.tsx
@@ -8,9 +8,9 @@ interface Props {
 }
 
 const TABS: { id: ViewMode; label: string }[] = [
-  { id: "semantic", label: "Semantic" },
-  { id: "accordion", label: "Accordion" },
   { id: "scrolling", label: "Scrolling" },
+  { id: "accordion", label: "Accordion" },
+  { id: "semantic", label: "Semantic" },
 ];
 
 export default function ViewTabs({ active, onChange }: Props) {


### PR DESCRIPTION
Closes #3

## Summary
- `AccordionView` component groups document content by section, each collapsed by default
- Collapsed sections show a blue border/header (signalling expandability) and a paragraph count hint
- Clicking a header expands all segments in that section; expanded sections revert to gray
- Sections expand/collapse independently
- Tab order updated to Scrolling → Accordion → Semantic