### PR TITLE
Add SemanticZoomView — per-section depth zoom with selective inline expansion

### DIFF
--- a/SemanticText/src/App.tsx
+++ b/SemanticText/src/App.tsx
@@ -2,19 +2,14 @@ import { useState } from "react";
 import ViewTabs, { type ViewMode } from "./components/ViewTabs";
 import ScrollView from "./components/ScrollView";
 import AccordionView from "./components/AccordionView";
-import type { Document } from "./data/types";
+import SemanticZoomView from "./components/SemanticZoomView";
+import type { Document, SemanticDocument } from "./data/types";
 import beatlesData from "./data/beatles.json";
+import beatlesSemanticData from "./data/beatles-semantic.json";
 import "./App.css";
 
 const doc = beatlesData as Document;
-
-function Placeholder({ label }: { label: string }) {
-  return (
-    <div className="placeholder">
-      <p>{label} view — coming soon.</p>
-    </div>
-  );
-}
+const semanticDoc = beatlesSemanticData as unknown as SemanticDocument;
 
 export default function App() {
   const [mode, setMode] = useState<ViewMode>("scrolling");
@@ -28,7 +23,7 @@ export default function App() {
       <main className="app-content">
         {mode === "scrolling" && <ScrollView doc={doc} />}
         {mode === "accordion" && <AccordionView doc={doc} />}
-        {mode === "semantic" && <Placeholder label="Semantic Zoom" />}
+        {mode === "semantic" && <SemanticZoomView doc={semanticDoc} />}
       </main>
     </div>
   );

--- a/SemanticText/src/components/SemanticZoomView.css
+++ b/SemanticText/src/components/SemanticZoomView.css
@@ -1,0 +1,142 @@
+.sz-view {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 2rem 1rem 4rem;
+  font-family: Georgia, "Times New Roman", serif;
+  line-height: 1.75;
+  color: #1a1a1a;
+}
+
+.sz-doc-title {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  border-bottom: 2px solid #e0e0e0;
+  padding-bottom: 0.75rem;
+}
+
+/* ── Hint ──────────────────────────────────────────────── */
+
+.sz-hint {
+  font-size: 0.78rem;
+  font-family: system-ui, sans-serif;
+  color: #aaa;
+  margin-bottom: 2rem;
+  font-style: italic;
+}
+
+/* ── Sections ──────────────────────────────────────────── */
+
+.sz-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.sz-section {
+  border-left: 3px solid #e0e0e0;
+  padding-left: 1rem;
+  transition: border-color 0.2s;
+}
+
+.sz-section--collapsed {
+  border-left-color: #1a73e8;
+}
+
+/* ── Section title (clickable) ─────────────────────────── */
+
+.sz-section-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #222;
+  cursor: pointer;
+  margin-bottom: 0.6rem;
+  padding: 0.2rem 0;
+  user-select: none;
+  border-radius: 3px;
+  transition: color 0.12s;
+}
+
+.sz-section-title:hover {
+  color: #1a73e8;
+}
+
+.sz-section-title:focus-visible {
+  outline: 2px solid #1a73e8;
+  outline-offset: 3px;
+}
+
+.sz-section-chevron {
+  font-size: 0.65rem;
+  color: #aaa;
+  flex-shrink: 0;
+  margin-left: 0.5rem;
+}
+
+/* ── Layer fade-in ─────────────────────────────────────── */
+
+@keyframes sz-fade-in {
+  from { opacity: 0; transform: translateY(3px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.sz-fade-in {
+  animation: sz-fade-in 0.2s ease both;
+}
+
+/* ── Paragraph segments ────────────────────────────────── */
+
+.sz-segment {
+  margin-bottom: 0.7rem;
+  border-radius: 3px;
+  transition: background 0.12s;
+}
+
+.sz-segment:last-child {
+  margin-bottom: 0;
+}
+
+/* Expandable lines: show they are interactive */
+.sz-segment--expandable {
+  cursor: pointer;
+  padding: 0.15rem 0.3rem 0.15rem 0;
+  border-bottom: 1px dotted #bbb;
+}
+
+.sz-segment--expandable:hover {
+  background: #f5f8ff;
+  border-bottom-color: #1a73e8;
+}
+
+.sz-segment--expandable:focus-visible {
+  outline: 2px solid #1a73e8;
+  outline-offset: 2px;
+}
+
+/* When expanded, the paragraph shows the full text */
+.sz-segment--expanded {
+  border-bottom-style: solid;
+  border-bottom-color: #1a73e8;
+  background: #f5f8ff;
+}
+
+.sz-segment--expanded:hover {
+  background: #eaf1ff;
+}
+
+/* Expand/collapse indicator appended inline */
+.sz-expand-indicator {
+  font-size: 0.6rem;
+  color: #aaa;
+  margin-left: 0.25rem;
+  vertical-align: middle;
+}
+
+/* ── Term text (italic, non-interactive) ───────────────── */
+
+.sz-term-text {
+  font-style: italic;
+}

--- a/SemanticText/src/components/SemanticZoomView.tsx
+++ b/SemanticText/src/components/SemanticZoomView.tsx
@@ -1,0 +1,189 @@
+import { useState, useEffect, useRef } from "react";
+import type { SemanticDocument, SZSection, SZLayer, SZParagraph, Token } from "../data/types";
+import "./SemanticZoomView.css";
+
+interface Props {
+  doc: SemanticDocument;
+}
+
+function maxLayerDepth(doc: SemanticDocument): number {
+  let max = 0;
+  for (const section of doc.sections) {
+    for (const layer of section.layers) {
+      if (layer.depth > max) max = layer.depth;
+    }
+  }
+  return max;
+}
+
+function layerForDepth(layers: SZLayer[], depth: number): SZLayer | undefined {
+  const candidates = layers.filter((l) => l.depth <= depth);
+  return candidates.length > 0 ? candidates[candidates.length - 1] : undefined;
+}
+
+function fullParagraph(section: SZSection, id: string): SZParagraph | undefined {
+  for (const layer of section.layers) {
+    const found = layer.paragraphs.find((p) => p.id === id);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function renderTokens(tokens: Token[]) {
+  return tokens.map((tok, i) =>
+    tok.type === "term"
+      ? <span key={i} className="sz-term-text">{tok.text}</span>
+      : <span key={i}>{tok.text}</span>
+  );
+}
+
+interface ParagraphRowProps {
+  para: SZParagraph;
+  section: SZSection;
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+function ParagraphRow({ para, section, expanded, onToggle }: ParagraphRowProps) {
+  const isExpandable = !!para.expandsToId;
+  const fullPara = para.expandsToId ? fullParagraph(section, para.expandsToId) : undefined;
+  const tokensToShow = expanded && fullPara ? fullPara.tokens : para.tokens;
+
+  return (
+    <p
+      className={`sz-segment${isExpandable ? " sz-segment--expandable" : ""}${expanded ? " sz-segment--expanded" : ""}`}
+      onClick={isExpandable ? onToggle : undefined}
+      role={isExpandable ? "button" : undefined}
+      tabIndex={isExpandable ? 0 : undefined}
+      onKeyDown={
+        isExpandable
+          ? (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onToggle(); } }
+          : undefined
+      }
+    >
+      {renderTokens(tokensToShow)}
+      {isExpandable && (
+        <span className="sz-expand-indicator" aria-hidden="true">
+          {expanded ? " ▲" : " ▼"}
+        </span>
+      )}
+    </p>
+  );
+}
+
+export default function SemanticZoomView({ doc }: Props) {
+  const maxDepth = maxLayerDepth(doc);
+
+  // Each section tracks its own depth independently.
+  const [sectionDepths, setSectionDepths] = useState<Record<string, number>>(
+    () => Object.fromEntries(doc.sections.map((s) => [s.id, 0]))
+  );
+
+  // Per-paragraph expansion, keyed as "sectionId:paragraphId"
+  const [expandedParagraphs, setExpandedParagraphs] = useState<Set<string>>(new Set());
+
+  const containerRef = useRef<HTMLElement>(null);
+
+  // Section title click: toggle between 0 (heading only) and maxDepth (full).
+  function toggleSection(sectionId: string) {
+    setSectionDepths((prev) => ({
+      ...prev,
+      [sectionId]: prev[sectionId] === 0 ? maxDepth : 0,
+    }));
+    // Clear per-paragraph expansions for this section.
+    setExpandedParagraphs((prev) => {
+      const next = new Set(prev);
+      for (const key of next) {
+        if (key.startsWith(`${sectionId}:`)) next.delete(key);
+      }
+      return next;
+    });
+  }
+
+  function toggleParagraph(sectionId: string, paraId: string) {
+    const key = `${sectionId}:${paraId}`;
+    setExpandedParagraphs((prev) => {
+      const next = new Set(prev);
+      next.has(key) ? next.delete(key) : next.add(key);
+      return next;
+    });
+  }
+
+  // Shift+Scroll: nudge every section's depth by ±1, each clamped independently.
+  // Sections at different depths drift apart or converge naturally.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    function handleWheel(e: WheelEvent) {
+      if (!e.shiftKey) return;
+      e.preventDefault();
+      setSectionDepths((prev) => {
+        const next = { ...prev };
+        for (const id of Object.keys(next)) {
+          if (e.deltaY < 0) next[id] = Math.min(next[id] + 1, maxDepth);
+          else if (e.deltaY > 0) next[id] = Math.max(next[id] - 1, 0);
+        }
+        return next;
+      });
+    }
+
+    el.addEventListener("wheel", handleWheel, { passive: false });
+    return () => el.removeEventListener("wheel", handleWheel);
+  }, [maxDepth]);
+
+  return (
+    <article className="sz-view" ref={containerRef}>
+      <h1 className="sz-doc-title">{doc.title}</h1>
+
+      <p className="sz-hint" aria-hidden="true">
+        Shift + scroll to zoom · click a line to expand · click a heading to collapse or open fully
+      </p>
+
+      <div className="sz-sections">
+        {doc.sections.map((section) => {
+          const depth = sectionDepths[section.id] ?? 0;
+          const layer = depth > 0 ? layerForDepth(section.layers, depth) : undefined;
+          const isCollapsed = depth === 0;
+
+          return (
+            <section
+              key={section.id}
+              className={`sz-section${isCollapsed ? " sz-section--collapsed" : ""}`}
+            >
+              <h2
+                className="sz-section-title"
+                onClick={() => toggleSection(section.id)}
+                role="button"
+                tabIndex={0}
+                aria-expanded={!isCollapsed}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleSection(section.id); }
+                }}
+              >
+                {section.title}
+                <span className="sz-section-chevron" aria-hidden="true">
+                  {isCollapsed ? "▼" : "▲"}
+                </span>
+              </h2>
+
+              {layer && (
+                <div className="sz-layer sz-fade-in" key={`${section.id}-d${layer.depth}`}>
+                  {layer.paragraphs.map((para) => (
+                    <ParagraphRow
+                      key={para.id}
+                      para={para}
+                      section={section}
+                      expanded={expandedParagraphs.has(`${section.id}:${para.id}`)}
+                      onToggle={() => toggleParagraph(section.id, para.id)}
+                    />
+                  ))}
+                </div>
+              )}
+            </section>
+          );
+        })}
+      </div>
+    </article>
+  );
+}

--- a/SemanticText/src/data/beatles-semantic.json
+++ b/SemanticText/src/data/beatles-semantic.json
@@ -1,0 +1,435 @@
+{
+  "id": "beatles-semantic",
+  "title": "The Beatles",
+  "sections": [
+    {
+      "id": "origins",
+      "title": "Origins",
+      "layers": [
+        {
+          "depth": 1,
+          "paragraphs": [
+            {
+              "id": "o-d1-p1",
+              "expandsToId": "o-d3-p1",
+              "tokens": [
+                { "type": "text", "text": "An English rock band formed in Liverpool" }
+              ]
+            },
+            {
+              "id": "o-d1-p2",
+              "expandsToId": "o-d3-p2",
+              "tokens": [
+                { "type": "text", "text": "Evolved from outfits led by John Lennon" }
+              ]
+            },
+            {
+              "id": "o-d1-p3",
+              "expandsToId": "o-d3-p3",
+              "tokens": [
+                { "type": "text", "text": "Honed their performance in Hamburg" }
+              ]
+            }
+          ]
+        },
+        {
+          "depth": 2,
+          "paragraphs": [
+            {
+              "id": "o-d2-p1",
+              "expandsToId": "o-d3-p1",
+              "tokens": [
+                { "type": "text", "text": "The Beatles were an English rock band formed in Liverpool in 1960." }
+              ]
+            },
+            {
+              "id": "o-d2-p2",
+              "expandsToId": "o-d3-p2",
+              "tokens": [
+                { "type": "text", "text": "They evolved from rock and roll outfits led by John Lennon, most notably The Quarrymen." }
+              ]
+            },
+            {
+              "id": "o-d2-p3",
+              "expandsToId": "o-d3-p3",
+              "tokens": [
+                { "type": "text", "text": "The band honed their live performance in Hamburg, West Germany between 1960 and 1962." }
+              ]
+            }
+          ]
+        },
+        {
+          "depth": 3,
+          "paragraphs": [
+            {
+              "id": "o-d3-p1",
+              "tokens": [
+                { "type": "text", "text": "The Beatles were an English rock band formed in " },
+                { "type": "term", "text": "Liverpool", "elaboration": "A port city in northwest England, Liverpool had a thriving music scene in the late 1950s centred around venues like the Cavern Club, where the Beatles played nearly 300 times." },
+                { "type": "text", "text": " in 1960. They became the most commercially successful and critically acclaimed band in the history of popular music." }
+              ]
+            },
+            {
+              "id": "o-d3-p2",
+              "tokens": [
+                { "type": "text", "text": "The group evolved from earlier skiffle and rock and roll outfits led by " },
+                { "type": "term", "text": "John Lennon", "elaboration": "John Lennon (1940–1980) was the founding member, rhythm guitarist, and principal creative force behind the Beatles' early direction. He was shot and killed outside his New York apartment on 8 December 1980." },
+                { "type": "text", "text": ", most notably The Quarrymen, formed in 1956. Paul McCartney joined that year and George Harrison followed in 1958, before Ringo Starr replaced Pete Best as drummer in 1962." }
+              ]
+            },
+            {
+              "id": "o-d3-p3",
+              "tokens": [
+                { "type": "text", "text": "The band honed their live performance across nearly 1,200 shows in " },
+                { "type": "term", "text": "Hamburg, West Germany", "elaboration": "Between 1960 and 1962 the Beatles completed five residencies in Hamburg, playing clubs like the Indra and the Star-Club for up to eight hours a night. The gruelling schedule forged their tight ensemble sound." },
+                { "type": "text", "text": " between 1960 and 1962, developing a raw, energetic stage presence before returning to Liverpool and signing with producer " },
+                { "type": "term", "text": "George Martin", "elaboration": "George Martin (1926–2016) was the Beatles' producer at EMI's Abbey Road Studios throughout their career. Often called 'the Fifth Beatle', he orchestrated the instrumental elements that translated their ideas into recorded sound." },
+                { "type": "text", "text": " at EMI's Parlophone label." }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "members",
+      "title": "Members",
+      "layers": [
+        {
+          "depth": 1,
+          "paragraphs": [
+            {
+              "id": "m-d1-p1",
+              "expandsToId": "m-d3-p1",
+              "tokens": [
+                { "type": "text", "text": "Lennon, McCartney, Harrison, and Starr — a celebrated songwriting partnership" }
+              ]
+            },
+            {
+              "id": "m-d1-p2",
+              "expandsToId": "m-d3-p2",
+              "tokens": [
+                { "type": "text", "text": "McCartney on bass, Harrison on guitar, Starr replaced Pete Best" }
+              ]
+            },
+            {
+              "id": "m-d1-p3",
+              "expandsToId": "m-d3-p3",
+              "tokens": [
+                { "type": "text", "text": "Harrison's Indian music interest sparked by Ravi Shankar" }
+              ]
+            }
+          ]
+        },
+        {
+          "depth": 2,
+          "paragraphs": [
+            {
+              "id": "m-d2-p1",
+              "expandsToId": "m-d3-p1",
+              "tokens": [
+                { "type": "text", "text": "The classic lineup consisted of John Lennon, Paul McCartney, George Harrison, and Ringo Starr." }
+              ]
+            },
+            {
+              "id": "m-d2-p2",
+              "expandsToId": "m-d3-p2",
+              "tokens": [
+                { "type": "text", "text": "McCartney played bass and shared lead vocals; Harrison's guitar drew on rockabilly and Indian classical influences; Starr replaced Pete Best as drummer in 1962." }
+              ]
+            },
+            {
+              "id": "m-d2-p3",
+              "expandsToId": "m-d3-p3",
+              "tokens": [
+                { "type": "text", "text": "Harrison's interest in Indian music — sparked by meeting Ravi Shankar in 1966 — introduced the sitar to Western pop." }
+              ]
+            }
+          ]
+        },
+        {
+          "depth": 3,
+          "paragraphs": [
+            {
+              "id": "m-d3-p1",
+              "tokens": [
+                { "type": "text", "text": "The classic lineup consisted of John Lennon, Paul McCartney, George Harrison, and Ringo Starr. Lennon and McCartney formed one of the most celebrated songwriting partnerships in popular music; Harrison contributed guitar work and later his own compositions; Starr provided the rhythmic foundation on drums." }
+              ]
+            },
+            {
+              "id": "m-d3-p2",
+              "tokens": [
+                { "type": "text", "text": "McCartney played bass and shared lead vocal duties with Lennon, while Harrison's guitar style drew on American rockabilly and later Indian classical influences. Starr replaced the more technically proficient Pete Best shortly before the band's breakthrough, a decision that proved pivotal: his distinctive, understated drumming became inseparable from the Beatles' sound." }
+              ]
+            },
+            {
+              "id": "m-d3-p3",
+              "tokens": [
+                { "type": "text", "text": "Harrison's growing interest in Indian music — sparked by meeting " },
+                { "type": "term", "text": "Ravi Shankar", "elaboration": "Ravi Shankar (1920–2012) was the pre-eminent sitar virtuoso of the 20th century. He tutored Harrison in 1966 and the two maintained a close friendship until Shankar's death." },
+                { "type": "text", "text": " in 1966 — introduced the sitar to Western pop on tracks such as 'Norwegian Wood' and later shaped the texture of entire albums." }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "career",
+      "title": "Musical Career",
+      "layers": [
+        {
+          "depth": 1,
+          "paragraphs": [
+            {
+              "id": "c-d1-p1",
+              "expandsToId": "c-d3-p1",
+              "tokens": [
+                { "type": "text", "text": "Debut album Please Please Me in 1963" }
+              ]
+            },
+            {
+              "id": "c-d1-p2",
+              "expandsToId": "c-d3-p2",
+              "tokens": [
+                { "type": "text", "text": "Key albums from Merseybeat to psychedelic experimentation" }
+              ]
+            },
+            {
+              "id": "c-d1-p3",
+              "expandsToId": "c-d3-p3",
+              "tokens": [
+                { "type": "text", "text": "Sgt. Pepper's in 1967 — widely the most influential record" }
+              ]
+            }
+          ]
+        },
+        {
+          "depth": 2,
+          "paragraphs": [
+            {
+              "id": "c-d2-p1",
+              "expandsToId": "c-d3-p1",
+              "tokens": [
+                { "type": "text", "text": "The Beatles released their debut album Please Please Me in 1963 and spent the decade redefining popular music." }
+              ]
+            },
+            {
+              "id": "c-d2-p2",
+              "expandsToId": "c-d3-p2",
+              "tokens": [
+                { "type": "text", "text": "Key albums traced an arc from Merseybeat to psychedelic experimentation: A Hard Day's Night (1964), Rubber Soul (1965), Revolver (1966), and Let It Be (1970)." }
+              ]
+            },
+            {
+              "id": "c-d2-p3",
+              "expandsToId": "c-d3-p3",
+              "tokens": [
+                { "type": "text", "text": "Their 1967 album Sgt. Pepper's consolidated the album as an artistic statement, widely considered the most influential record in popular music history." }
+              ]
+            }
+          ]
+        },
+        {
+          "depth": 3,
+          "paragraphs": [
+            {
+              "id": "c-d3-p1",
+              "tokens": [
+                { "type": "text", "text": "The Beatles released their debut album " },
+                { "type": "term", "text": "Please Please Me", "elaboration": "Released 22 March 1963 on Parlophone, Please Please Me was recorded in a single marathon session lasting just under ten hours. It reached number one on the UK Albums Chart." },
+                { "type": "text", "text": " in 1963 and spent the decade redefining what popular music could be. Their studio output culminated in landmark records that transformed both the sonic and cultural possibilities of the album format." }
+              ]
+            },
+            {
+              "id": "c-d3-p2",
+              "tokens": [
+                { "type": "text", "text": "Key albums across their career trace an arc from danceable Merseybeat to psychedelic experimentation and back to stripped-back rock: A Hard Day's Night (1964) — their first album composed entirely of original material, coinciding with their film debut and US breakthrough. Rubber Soul (1965) — a pivot toward folk rock and introspective lyricism that influenced Bob Dylan and Brian Wilson. " },
+                { "type": "term", "text": "Revolver", "elaboration": "Released August 1966, Revolver is frequently ranked the greatest album ever made. It introduced studio techniques — tape loops, backward guitars, orchestral collages — that redefined what a recording studio could do." },
+                { "type": "text", "text": " (1966) — a studio breakthrough blending Indian classical, avant-garde, and pop. Let It Be (1970) — a deliberately raw return to live performance, released after the band had already dissolved." }
+              ]
+            },
+            {
+              "id": "c-d3-p3",
+              "tokens": [
+                { "type": "text", "text": "Their 1967 album " },
+                { "type": "term", "text": "Sgt. Pepper's Lonely Hearts Club Band", "elaboration": "Released 1 June 1967, Sgt. Pepper's spent 27 weeks at number one in the UK and is widely regarded as the first 'concept album'. It won four Grammy Awards in 1968, including Album of the Year." },
+                { "type": "text", "text": " is widely considered the most influential record in popular music history, consolidating the album as an artistic statement rather than a collection of singles. Its recording required 700 hours of studio time and producer " },
+                { "type": "term", "text": "George Martin", "elaboration": "George Martin (1926–2016) was the Beatles' producer at EMI's Abbey Road Studios throughout their career. Often called 'the Fifth Beatle', he orchestrated and arranged the instrumental elements that translated their ideas into recorded sound." },
+                { "type": "text", "text": " orchestrated its elaborate arrangements, including the famous 41-piece orchestra crescendo that closes 'A Day in the Life'." }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cultural-impact",
+      "title": "Cultural Impact",
+      "layers": [
+        {
+          "depth": 1,
+          "paragraphs": [
+            {
+              "id": "ci-d1-p1",
+              "expandsToId": "ci-d3-p1",
+              "tokens": [
+                { "type": "text", "text": "Triggered Beatlemania in Britain in 1963" }
+              ]
+            },
+            {
+              "id": "ci-d1-p2",
+              "expandsToId": "ci-d3-p2",
+              "tokens": [
+                { "type": "text", "text": "Shaped fashion, language, and countercultural politics" }
+              ]
+            },
+            {
+              "id": "ci-d1-p3",
+              "expandsToId": "ci-d3-p3",
+              "tokens": [
+                { "type": "text", "text": "1968 Rishikesh visit with Maharishi Mahesh Yogi" }
+              ]
+            }
+          ]
+        },
+        {
+          "depth": 2,
+          "paragraphs": [
+            {
+              "id": "ci-d2-p1",
+              "expandsToId": "ci-d3-p1",
+              "tokens": [
+                { "type": "text", "text": "The Beatles triggered Beatlemania that swept Britain in 1963 and the United States in 1964, drawing 73 million viewers on The Ed Sullivan Show." }
+              ]
+            },
+            {
+              "id": "ci-d2-p2",
+              "expandsToId": "ci-d3-p2",
+              "tokens": [
+                { "type": "text", "text": "Beyond music, the Beatles shaped fashion, language, and countercultural politics throughout the 1960s." }
+              ]
+            },
+            {
+              "id": "ci-d2-p3",
+              "expandsToId": "ci-d3-p3",
+              "tokens": [
+                { "type": "text", "text": "Their 1968 visit to study under Maharishi Mahesh Yogi in Rishikesh yielded approximately 48 songs, many filling the double White Album." }
+              ]
+            }
+          ]
+        },
+        {
+          "depth": 3,
+          "paragraphs": [
+            {
+              "id": "ci-d3-p1",
+              "tokens": [
+                { "type": "text", "text": "The Beatles triggered a cultural phenomenon known as " },
+                { "type": "term", "text": "Beatlemania", "elaboration": "Beatlemania refers to the intense fan frenzy that surrounded the Beatles from 1963 onward. Concerts were frequently inaudible over sustained screaming; airports required police cordons; the band ultimately stopped touring in 1966 because live performance had become logistically and artistically untenable." },
+                { "type": "text", "text": " that swept Britain in 1963 and the United States in 1964. Their appearance on The Ed Sullivan Show on 9 February 1964 attracted an estimated 73 million viewers and effectively launched the British Invasion of American popular music." }
+              ]
+            },
+            {
+              "id": "ci-d3-p2",
+              "tokens": [
+                { "type": "text", "text": "Beyond music, the Beatles shaped fashion, language, and countercultural politics throughout the 1960s. Their embrace of Transcendental Meditation, psychedelic imagery, and anti-war sentiment aligned them with the broader counterculture and gave their cultural authority a reach well beyond the pop charts." }
+              ]
+            },
+            {
+              "id": "ci-d3-p3",
+              "tokens": [
+                { "type": "text", "text": "The band's 1968 visit to study under " },
+                { "type": "term", "text": "Maharishi Mahesh Yogi", "elaboration": "Maharishi Mahesh Yogi (1918–2008) was an Indian guru who developed the Transcendental Meditation technique. The Beatles' stay at his ashram in Rishikesh, India, proved one of their most prolific creative periods: approximately 48 songs were written there, many of which appeared on the White Album." },
+                { "type": "text", "text": " in Rishikesh, India produced one of the most prolific songwriting bursts of their career, yielding material that would fill the double White Album released later that year." }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "disbandment-legacy",
+      "title": "Disbandment and Legacy",
+      "layers": [
+        {
+          "depth": 1,
+          "paragraphs": [
+            {
+              "id": "dl-d1-p1",
+              "expandsToId": "dl-d3-p1",
+              "tokens": [
+                { "type": "text", "text": "Disbanded in 1970; best-selling music act with 600 million units" }
+              ]
+            },
+            {
+              "id": "dl-d1-p2",
+              "expandsToId": "dl-d3-p2",
+              "tokens": [
+                { "type": "text", "text": "Split over management after Brian Epstein's death and Lennon's departure" }
+              ]
+            },
+            {
+              "id": "dl-d1-p3",
+              "expandsToId": "dl-d3-p3",
+              "tokens": [
+                { "type": "text", "text": "'Now and Then' released in 2023 using AI audio separation" }
+              ]
+            }
+          ]
+        },
+        {
+          "depth": 2,
+          "paragraphs": [
+            {
+              "id": "dl-d2-p1",
+              "expandsToId": "dl-d3-p1",
+              "tokens": [
+                { "type": "text", "text": "The Beatles disbanded in 1970 following mounting tensions, having released 13 studio albums and 20 number-one UK singles." }
+              ]
+            },
+            {
+              "id": "dl-d2-p2",
+              "expandsToId": "dl-d3-p2",
+              "tokens": [
+                { "type": "text", "text": "The split followed Brian Epstein's death in 1967 and John Lennon's public announcement in September 1969 that he was leaving." }
+              ]
+            },
+            {
+              "id": "dl-d2-p3",
+              "expandsToId": "dl-d3-p3",
+              "tokens": [
+                { "type": "text", "text": "In 2023 the final Beatles song 'Now and Then' reached number one in the UK, using AI audio separation to restore Lennon's voice." }
+              ]
+            }
+          ]
+        },
+        {
+          "depth": 3,
+          "paragraphs": [
+            {
+              "id": "dl-d3-p1",
+              "tokens": [
+                { "type": "text", "text": "The Beatles disbanded in 1970 following mounting personal and business tensions. Despite a career spanning only a decade, they released 13 studio albums and 20 number-one singles in the UK. They remain the best-selling music act in history, with estimated sales exceeding 600 million units worldwide." }
+              ]
+            },
+            {
+              "id": "dl-d3-p2",
+              "tokens": [
+                { "type": "text", "text": "The immediate cause of the split was a dispute over management following the death of their manager Brian Epstein in 1967, compounded by creative divergence and John Lennon's public declaration in September 1969 that he was leaving the band. Paul McCartney's announcement in April 1970 made the dissolution official." }
+              ]
+            },
+            {
+              "id": "dl-d3-p3",
+              "tokens": [
+                { "type": "text", "text": "Legal battles over the Apple Corps partnership continued until 1989. In 2023, the final Beatles song — 'Now and Then', a Lennon demo restored using " },
+                { "type": "term", "text": "AI audio separation technology", "elaboration": "Peter Jackson's production team used machine-learning-based audio source separation (developed during the Get Back documentary) to isolate Lennon's voice from a low-fidelity cassette demo, enabling McCartney, Harrison (via archival guitar tracks), and Starr to complete the recording." },
+                { "type": "text", "text": " — was released, reaching number one in the UK and becoming the band's first chart-topper in over 54 years." }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/SemanticText/src/data/types.ts
+++ b/SemanticText/src/data/types.ts
@@ -28,3 +28,33 @@ export interface Document {
   title: string;
   sections: Section[];
 }
+
+// ── Semantic Zoom document ─────────────────────────────────────────────────
+// Each section has discrete layers (depth 1 = compressed summary,
+// depth 2 = short paragraphs, depth 3 = full text). The same concepts
+// appear in the same order at every depth level.
+
+export interface SZParagraph {
+  id: string;
+  tokens: Token[];
+  // References a depth-3 paragraph in the same section; clicking the whole
+  // paragraph expands it inline to show that full content.
+  expandsToId?: string;
+}
+
+export interface SZLayer {
+  depth: number;
+  paragraphs: SZParagraph[];
+}
+
+export interface SZSection {
+  id: string;
+  title: string;
+  layers: SZLayer[];
+}
+
+export interface SemanticDocument {
+  id: string;
+  title: string;
+  sections: SZSection[];
+}


### PR DESCRIPTION
## Summary
- New `SemanticDocument` type with a layered structure (depth 1–3 per section), separate from the existing `Document` used by Scroll/Accordion views
- `beatles-semantic.json`: 3 short fragment lines per section at depth 1, concise paragraphs at depth 2, full text at depth 3; each paragraph carries an `expandsToId` referencing its depth-3 counterpart
- `SemanticZoomView`: Shift+Scroll nudges every section's depth independently (±1, clamped at 0/max); sections at different depths naturally re-sync when they all hit the same extreme
- Clicking a section heading toggles that section between heading-only and full text, while remaining responsive to shift+scroll
- Clicking any fragment or paragraph line expands it inline to its full content; other lines in the section are unaffected

## Test plan
- [ ] Shift+scroll up/down zooms all sections; sections manually expanded/collapsed still respond and re-sync at extremes
- [ ] Clicking a depth-1 fragment line expands only that line to its full paragraph; the other two lines stay as fragments
- [ ] Clicking an expanded line collapses it back to the fragment
- [ ] Clicking a section heading collapses it to heading-only; clicking again expands to full text
- [ ] Scroll/Accordion tabs are unaffected

Closes #5