### PR TITLE
Quiz split-screen: 5-question MCQ alongside the reader

### DIFF
--- a/SemanticText/src/App.css
+++ b/SemanticText/src/App.css
@@ -26,6 +26,11 @@
   overflow-y: auto;
 }
 
+/* In quiz/split mode the inner SplitView manages its own scrolling */
+.app-shell--split .app-content {
+  overflow: hidden;
+}
+
 .placeholder {
   display: flex;
   align-items: center;

--- a/SemanticText/src/App.tsx
+++ b/SemanticText/src/App.tsx
@@ -1,8 +1,6 @@
 import { useState } from "react";
 import ViewTabs, { type ViewMode } from "./components/ViewTabs";
-import ScrollView from "./components/ScrollView";
-import AccordionView from "./components/AccordionView";
-import SemanticZoomView from "./components/SemanticZoomView";
+import SplitView from "./components/SplitView";
 import type { Document, SemanticDocument } from "./data/types";
 import beatlesData from "./data/beatles.json";
 import beatlesSemanticData from "./data/beatles-semantic.json";
@@ -15,15 +13,13 @@ export default function App() {
   const [mode, setMode] = useState<ViewMode>("scrolling");
 
   return (
-    <div className="app-shell">
+    <div className="app-shell app-shell--split">
       <header className="app-header">
         <span className="app-brand">Textual Semantic Zoom</span>
       </header>
       <ViewTabs active={mode} onChange={setMode} />
       <main className="app-content">
-        {mode === "scrolling" && <ScrollView doc={doc} />}
-        {mode === "accordion" && <AccordionView doc={doc} />}
-        {mode === "semantic" && <SemanticZoomView doc={semanticDoc} />}
+        <SplitView mode={mode} doc={doc} semanticDoc={semanticDoc} />
       </main>
     </div>
   );

--- a/SemanticText/src/components/QuizPanel.css
+++ b/SemanticText/src/components/QuizPanel.css
@@ -1,0 +1,272 @@
+/* ── Quiz panel shell ─────────────────────────────────────── */
+
+.quiz-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #fafafa;
+  overflow-y: auto;
+}
+
+/* ── Header ───────────────────────────────────────────────── */
+
+.quiz-header {
+  padding: 1.5rem 1.5rem 1rem;
+  border-bottom: 1px solid #e4e4e4;
+  background: #fff;
+  flex-shrink: 0;
+}
+
+.quiz-title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #111;
+  margin: 0 0 0.35rem;
+}
+
+.quiz-subtitle {
+  font-size: 0.82rem;
+  color: #666;
+  line-height: 1.5;
+  margin: 0;
+}
+
+/* ── Question list ────────────────────────────────────────── */
+
+.quiz-questions {
+  list-style: none;
+  margin: 0;
+  padding: 1rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  flex: 1;
+}
+
+/* ── Individual question card ─────────────────────────────── */
+
+.quiz-question {
+  background: #fff;
+  border: 1px solid #e4e4e4;
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  transition: border-color 0.2s;
+}
+
+.quiz-question--correct {
+  border-color: #34a853;
+  background: #f6fef9;
+}
+
+.quiz-question--wrong {
+  border-color: #ea4335;
+  background: #fff8f7;
+}
+
+.quiz-question-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.55rem;
+}
+
+.quiz-q-number {
+  font-size: 0.7rem;
+  font-weight: 700;
+  background: #1a73e8;
+  color: #fff;
+  border-radius: 3px;
+  padding: 0.1rem 0.4rem;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+  cursor: help;
+  text-decoration: underline dotted rgba(255, 255, 255, 0.6);
+  text-underline-offset: 2px;
+}
+
+.quiz-q-text {
+  font-size: 0.93rem;
+  font-weight: 600;
+  color: #1a1a1a;
+  margin: 0 0 0.85rem;
+  line-height: 1.45;
+}
+
+/* ── Options fieldset ─────────────────────────────────────── */
+
+.quiz-options {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.quiz-options:disabled .quiz-option {
+  cursor: default;
+}
+
+/* ── Option label ─────────────────────────────────────────── */
+
+.quiz-option {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.45rem 0.65rem;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  cursor: pointer;
+  background: #fafafa;
+  transition: background 0.12s, border-color 0.12s;
+  font-size: 0.88rem;
+  color: #333;
+}
+
+.quiz-option:hover:not(:has(input:disabled)) {
+  background: #f0f4ff;
+  border-color: #1a73e8;
+}
+
+.quiz-option--selected {
+  background: #e8f0fe;
+  border-color: #1a73e8;
+  color: #1a1a1a;
+}
+
+.quiz-option--correct {
+  background: #e6f4ea;
+  border-color: #34a853;
+  color: #1e6e3a;
+  font-weight: 600;
+}
+
+.quiz-option--wrong {
+  background: #fce8e6;
+  border-color: #ea4335;
+  color: #b31412;
+}
+
+.quiz-option input[type="radio"] {
+  accent-color: #1a73e8;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
+.quiz-option-text {
+  flex: 1;
+}
+
+.quiz-option-mark {
+  font-size: 0.85rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.quiz-option-mark--correct {
+  color: #34a853;
+}
+
+.quiz-option-mark--wrong {
+  color: #ea4335;
+}
+
+/* ── Footer / submit / result ─────────────────────────────── */
+
+.quiz-footer {
+  padding: 1.25rem 1.5rem 2rem;
+  flex-shrink: 0;
+}
+
+.quiz-submit-btn {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  background: #1a73e8;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+}
+
+.quiz-submit-btn:hover:not(:disabled) {
+  background: #1558b0;
+}
+
+.quiz-submit-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.quiz-result {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  text-align: center;
+}
+
+.quiz-score {
+  font-size: 2rem;
+  font-weight: 700;
+  border-radius: 8px;
+  padding: 0.4rem 1.2rem;
+}
+
+.quiz-score--perfect {
+  color: #1e6e3a;
+  background: #e6f4ea;
+}
+
+.quiz-score--good {
+  color: #1a55a0;
+  background: #e8f0fe;
+}
+
+.quiz-score--low {
+  color: #b31412;
+  background: #fce8e6;
+}
+
+.quiz-result-msg {
+  font-size: 0.86rem;
+  color: #555;
+  line-height: 1.5;
+  margin: 0;
+  max-width: 28ch;
+}
+
+.quiz-reset-btn {
+  padding: 0.5rem 1.5rem;
+  font-size: 0.88rem;
+  font-weight: 600;
+  background: none;
+  border: 1.5px solid #1a73e8;
+  color: #1a73e8;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.quiz-reset-btn:hover {
+  background: #e8f0fe;
+}
+
+/* ── Accessibility ────────────────────────────────────────── */
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/SemanticText/src/components/QuizPanel.tsx
+++ b/SemanticText/src/components/QuizPanel.tsx
@@ -1,0 +1,167 @@
+import { useState } from "react";
+import "./QuizPanel.css";
+
+interface Question {
+  id: number;
+  text: string;
+  hint: string;
+  options: string[];
+  correct: number;
+}
+
+const QUESTIONS: Question[] = [
+  {
+    id: 1,
+    text: "Which city were The Beatles formed in?",
+    hint: "Depth 1 (skeleton) — Origins section",
+    options: ["London", "Manchester", "Liverpool", "Hamburg"],
+    correct: 2,
+  },
+  {
+    id: 2,
+    text: "How many viewers watched The Beatles' appearance on The Ed Sullivan Show in February 1964?",
+    hint: "Depth 2 — Cultural Impact section",
+    options: ["12 million", "35 million", "73 million", "100 million"],
+    correct: 2,
+  },
+  {
+    id: 3,
+    text: "How many studio albums did The Beatles release during their career?",
+    hint: "Depth 2 — Disbandment and Legacy section",
+    options: ["9", "11", "13", "15"],
+    correct: 2,
+  },
+  {
+    id: 4,
+    text: "How many musicians were in the orchestra that played the famous crescendo closing 'A Day in the Life'?",
+    hint: "Depth 3 (full expansion required) — Musical Career section",
+    options: ["21 musicians", "35 musicians", "41 musicians", "52 musicians"],
+    correct: 2,
+  },
+  {
+    id: 5,
+    text: "What nickname is often given to producer George Martin in relation to The Beatles?",
+    hint: "Depth 3 + click the 'George Martin' term — Origins section",
+    options: [
+      "The Silent Partner",
+      "The Sixth Beatle",
+      "The Hidden Hand",
+      "The Fifth Beatle",
+    ],
+    correct: 3,
+  },
+];
+
+export default function QuizPanel() {
+  const [selected, setSelected] = useState<Record<number, number>>({});
+  const [submitted, setSubmitted] = useState(false);
+
+  const allAnswered = QUESTIONS.every((q) => selected[q.id] !== undefined);
+
+  const score = submitted
+    ? QUESTIONS.filter((q) => selected[q.id] === q.correct).length
+    : 0;
+
+  function handleSelect(questionId: number, optionIndex: number) {
+    if (submitted) return;
+    setSelected((prev) => ({ ...prev, [questionId]: optionIndex }));
+  }
+
+  function handleSubmit() {
+    if (allAnswered) setSubmitted(true);
+  }
+
+  function handleReset() {
+    setSelected({});
+    setSubmitted(false);
+  }
+
+  return (
+    <div className="quiz-panel">
+      <div className="quiz-header">
+        <h2 className="quiz-title">Comprehension Quiz</h2>
+        <p className="quiz-subtitle">
+          Use the reader on the left to find the answers. Hover over a question
+          number for a hint.
+        </p>
+      </div>
+
+      <ol className="quiz-questions">
+        {QUESTIONS.map((q) => {
+          const isCorrect = submitted && selected[q.id] === q.correct;
+
+          return (
+            <li
+              key={q.id}
+              className={`quiz-question ${submitted ? (isCorrect ? "quiz-question--correct" : "quiz-question--wrong") : ""}`}
+            >
+              <div className="quiz-question-header">
+                <span className="quiz-q-number" title={q.hint} aria-label={`Question ${q.id} — hint: ${q.hint}`}>
+                  Q{q.id}
+                </span>
+              </div>
+              <p className="quiz-q-text">{q.text}</p>
+              <fieldset className="quiz-options" disabled={submitted}>
+                <legend className="sr-only">Options for question {q.id}</legend>
+                {q.options.map((opt, i) => {
+                  const isSelected = selected[q.id] === i;
+                  const isCorrectOption = submitted && i === q.correct;
+                  const isWrongSelection = submitted && isSelected && !isCorrectOption;
+                  return (
+                    <label
+                      key={i}
+                      className={`quiz-option ${isSelected ? "quiz-option--selected" : ""} ${isCorrectOption ? "quiz-option--correct" : ""} ${isWrongSelection ? "quiz-option--wrong" : ""}`}
+                    >
+                      <input
+                        type="radio"
+                        name={`q${q.id}`}
+                        value={i}
+                        checked={isSelected}
+                        onChange={() => handleSelect(q.id, i)}
+                      />
+                      <span className="quiz-option-text">{opt}</span>
+                      {isCorrectOption && (
+                        <span className="quiz-option-mark quiz-option-mark--correct">✓</span>
+                      )}
+                      {isWrongSelection && (
+                        <span className="quiz-option-mark quiz-option-mark--wrong">✗</span>
+                      )}
+                    </label>
+                  );
+                })}
+              </fieldset>
+            </li>
+          );
+        })}
+      </ol>
+
+      <div className="quiz-footer">
+        {!submitted ? (
+          <button
+            className="quiz-submit-btn"
+            onClick={handleSubmit}
+            disabled={!allAnswered}
+          >
+            Submit answers
+          </button>
+        ) : (
+          <div className="quiz-result">
+            <div className={`quiz-score ${score === QUESTIONS.length ? "quiz-score--perfect" : score >= 3 ? "quiz-score--good" : "quiz-score--low"}`}>
+              {score} / {QUESTIONS.length} correct
+            </div>
+            <p className="quiz-result-msg">
+              {score === QUESTIONS.length
+                ? "Perfect score — you zoomed to exactly the right depth every time."
+                : score >= 3
+                  ? "Good job! Check the highlighted answers to see what you missed."
+                  : "Try re-reading with the Semantic view and zooming deeper into each section."}
+            </p>
+            <button className="quiz-reset-btn" onClick={handleReset}>
+              Try again
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/SemanticText/src/components/SplitView.css
+++ b/SemanticText/src/components/SplitView.css
@@ -1,0 +1,60 @@
+/* ── Split layout ─────────────────────────────────────────── */
+
+.split-view {
+  display: flex;
+  height: 100%;
+  overflow: hidden;
+}
+
+/* ── Panes ────────────────────────────────────────────────── */
+
+.split-pane {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* ── Reader pane ──────────────────────────────────────────── */
+
+.split-pane--reader {
+  overflow-y: auto;
+}
+
+/* ── Vertical divider ─────────────────────────────────────── */
+
+.split-divider {
+  width: 1px;
+  background: #d8d8d8;
+  flex-shrink: 0;
+}
+
+/* ── Quiz pane ────────────────────────────────────────────── */
+
+.split-pane--quiz {
+  flex: 0 0 42%;
+  max-width: 480px;
+  min-width: 320px;
+  overflow: hidden;
+}
+
+/* ── Responsive: stack vertically on narrow viewports ─────── */
+
+@media (max-width: 900px) {
+  .split-view {
+    flex-direction: column;
+  }
+
+  .split-pane--quiz {
+    flex: 0 0 auto;
+    max-width: none;
+    min-width: 0;
+    height: 55vh;
+    border-top: 1px solid #d8d8d8;
+  }
+
+  .split-divider {
+    display: none;
+  }
+}

--- a/SemanticText/src/components/SplitView.tsx
+++ b/SemanticText/src/components/SplitView.tsx
@@ -1,0 +1,34 @@
+import ScrollView from "./ScrollView";
+import AccordionView from "./AccordionView";
+import SemanticZoomView from "./SemanticZoomView";
+import QuizPanel from "./QuizPanel";
+import type { ViewMode } from "./ViewTabs";
+import type { Document, SemanticDocument } from "../data/types";
+import "./SplitView.css";
+
+interface Props {
+  mode: ViewMode;
+  doc: Document;
+  semanticDoc: SemanticDocument;
+}
+
+export default function SplitView({ mode, doc, semanticDoc }: Props) {
+  return (
+    <div className="split-view">
+      {/* ── Left panel: reader (controlled by top-level tabs) ── */}
+      <div className="split-pane split-pane--reader">
+        {mode === "scrolling" && <ScrollView doc={doc} />}
+        {mode === "accordion" && <AccordionView doc={doc} />}
+        {mode === "semantic" && <SemanticZoomView doc={semanticDoc} />}
+      </div>
+
+      {/* ── Divider ─────────────────────────────────────────── */}
+      <div className="split-divider" aria-hidden="true" />
+
+      {/* ── Right panel: quiz (always visible) ──────────────── */}
+      <div className="split-pane split-pane--quiz">
+        <QuizPanel />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Always-visible split layout: reader on the left (Scrolling / Accordion / Semantic tabs controlled by the single top tab bar), quiz panel on the right — no duplicate headers
- `QuizPanel`: 5 MCQs requiring progressively deeper semantic zoom (depth 1 → depth 3 + term click), radio buttons, submit guard (disabled until all answered), per-question pass/fail colouring after submit
- Hints hidden from the visible UI; exposed only on hover over the `Q#` badge via native tooltip + `aria-label`
- Responsive: stacks vertically below 900 px

## Files changed

| File | Change |
|---|---|
| `App.tsx` | Always renders `SplitView`; passes active mode as prop |
| `App.css` | `app-shell--split` disables outer scroll |
| `SplitView.tsx` + `.css` | 50/50 flex layout, independent scroll per pane |
| `QuizPanel.tsx` + `.css` | MCQ quiz with full result display |

Closes #14